### PR TITLE
Fix the PONG response

### DIFF
--- a/irc/main.rkt
+++ b/irc/main.rkt
@@ -81,7 +81,7 @@
 (define (handle-ping message connection handler-key)
   (match message
     [(irc-message _ "PING" params _)
-     (irc-send-command connection "PONG" "pongresponse")]
+     (irc-send-command connection "PONG" (string-append ":" (first params)))]
     [_ (void)]))
 
 (define (irc-set-nick connection nick)


### PR DESCRIPTION
The parameter for PONG must be the one received in the PING message (see [rfc2812](https://tools.ietf.org/html/rfc2812#section-3.7.2)).

Otherwise, some servers (e.g. irc.geeknode.org) refuse to register the user and joining a channel is then impossible.