### PR TITLE
Ignore compiled Racket code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 irc/doc
+compiled


### PR DESCRIPTION
Was rereading the code and noticed the compiled dir isn't ignored :)