### PR TITLE
add ability to set a connection password

### DIFF
--- a/irc/main.rkt
+++ b/irc/main.rkt
@@ -98,10 +98,15 @@
 
 ;; Connects to an IRC server, returning the connection and an event that will be ready for
 ;; synchronization when the server is ready for more commands
-(define (irc-connect server port nick username real-name #:return-eof [return-eof #f] #:ssl [ssl #f])
+(define (irc-connect server port nick username real-name
+                     #:return-eof [return-eof #f]
+                     #:ssl [ssl #f]
+                     #:password [password #f])
   (define connection (irc-get-connection server port #:return-eof return-eof #:ssl ssl))
   (define sema (make-semaphore))
   (add-handler connection (listen-for-connect sema))
+  (when password
+    (irc-send-command connection "PASS" password))
   (irc-set-nick connection nick)
   (irc-set-user-info connection username real-name)
   (values connection sema))


### PR DESCRIPTION
Minor patch to implement the PASS command when connecting an irc client. I was messing around writing some twitch "bot" and needed to modify the `irc-connect` procedure to be able to successfully authenticate. It follows the RFC1459 spec, setting the connection password before registering the connection: 

https://datatracker.ietf.org/doc/html/rfc1459#section-4.1.1