### PR TITLE
Scan for IRC Messages by their CRLF delimiter

### DIFF
--- a/irc/main.rkt
+++ b/irc/main.rkt
@@ -49,7 +49,7 @@
   (thread (lambda ()
             (let loop ()
               (sync in)
-              (define line (if (port-closed? in) eof (read-line in)))
+              (define line (if (port-closed? in) eof (read-line in 'return-linefeed)))
               (cond
                [(eof-object? line)
                 (when return-eof


### PR DESCRIPTION
Looks like `read-line` scans by LF out of the box, but can be configured to
scan by CRLF, as per the IRC specification
https://datatracker.ietf.org/doc/html/rfc1459#section-2.3.1 .  I initially ran
into this bug because the retained CR was being logged to terminal, causing the
cursor to move to the beginning of the line and partially overwrite the log
line.