### PR TITLE
Switch Freenode references to Libera.Chat

### DIFF
--- a/irc/examples/disconnect-test.rkt
+++ b/irc/examples/disconnect-test.rkt
@@ -6,7 +6,7 @@
          racket/async-channel)
 
 (define-values (conn ready)
-  (irc-connect "chat.freenode.net" 6667 "rackbot" "rbot" "Racket Bot" #:return-eof #t))
+  (irc-connect "irc.libera.chat" 6667 "rackbot" "rbot" "Racket Bot" #:return-eof #t))
 
 (sync ready)
 

--- a/irc/examples/echobot.rkt
+++ b/irc/examples/echobot.rkt
@@ -4,7 +4,7 @@
 (require irc)
 
 (define-values (connection ready-event)
-  (irc-connect "chat.freenode.net" 6667 "schubot" "schubot" "Schuster's Echo Bot"))
+  (irc-connect "irc.libera.chat" 6667 "schubot" "schubot" "Schuster's Echo Bot"))
 (void (sync ready-event))
 
 (irc-join-channel connection "##racketirctest")

--- a/irc/irc.scrbl
+++ b/irc/irc.scrbl
@@ -13,12 +13,12 @@ The irc library allows you to develop IRC clients and communicate over IRC.
 @section{Quick Start}
 
 To use the IRC client library, first create a connection with @racket[irc-connect]. For example, to
-connect to the Freenode (chat.freenode.net, port 6667) with nickname "rackbot", username "rbot", and real
+connect to the Libera.Chat network (irc.libera.chat, port 6667) with nickname "rackbot", username "rbot", and real
 name "Racket Bot", do
 
 @racketblock[
 (define-values (connection ready)
-  (irc-connect "chat.freenode.net" 6667 "rackbot" "rbot" "Racket Bot"))]
+  (irc-connect "irc.libera.chat" 6667 "rackbot" "rbot" "Racket Bot"))]
 
 This defines an @racket[irc-connection] object which must be used for all future communication with
 this server, as well as an event that will be ready for synchronization when the server is ready to


### PR DESCRIPTION
Freenode was subjected to a hostile takeover in 2021, and most of the open source communities located there have moved on to libera.chat. Update references to match.